### PR TITLE
DRY up code and mandatory refactors

### DIFF
--- a/bnbphoneticparser/banglishtobengali.py
+++ b/bnbphoneticparser/banglishtobengali.py
@@ -9,37 +9,29 @@ class BanglishToBengali(BengaliPhoneticParser):
     def __change(self, txt, ch, nch):
         return txt.replace(ch, nch)
 
-    def _get_char_type(self, ch):
-        if ch in self.kar or ch in self.kar.values():
-            return 'k'
-        elif ch in self.shoroborno or ch in self.shoroborno.values():
-            return 'sb'
-        elif ch in self.byanjon_borno or ch in self.byanjon_borno.values():
-            return 'bb'
-
     def __change_sworborno(self, txt, ch):
-        sx = ""
+        sx = ''
         sx += txt
-        if ch.lower() == "a":
-            asx = ""
+        if ch == 'a':
+            asx = ''
             for i in range(0, len(txt)):
                 if i == 0:
-                    if txt[i].lower() == "a":
-                        asx += "আ"
+                    if txt[i] == 'a':
+                        asx += 'আ'
                     else:
                         asx += txt[i]
                 else:
-                    if txt[i].lower() == "a":
-                        prev_char_type = self._get_char_type(txt[i - 1])
-                        is_prev_one_kar_or_sworborno = prev_char_type == 'k' or prev_char_type == 'sb'
-                        is_prev_one_byanjon_borno = prev_char_type == 'bb'
+                    if txt[i] == 'a':
+                        is_prev_one_kar_or_sworborno = self._is_sworborno(txt[i - 1]) or self._is_kar(txt[i - 1])
+                        is_prev_one_byanjon_borno = self._is_byanjonborno(txt[i - 1])
+
                         if is_prev_one_kar_or_sworborno:
-                            if txt[i - 1] == "আ" or txt[i - 1] == "া" or txt[i - 1] == "a" or txt[i - 1] == "A":
-                                asx += "আ"
+                            if txt[i - 1] == 'আ' or txt[i - 1] == 'া' or txt[i - 1] == 'a' or txt[i - 1] == 'A':
+                                asx += 'আ'
                             else:
-                                asx += "য়া"
+                                asx += 'য়া'
                         elif is_prev_one_byanjon_borno:
-                            asx += "া"
+                            asx += 'া'
                     else:
                         asx += txt[i]
             return asx
@@ -54,10 +46,9 @@ class BanglishToBengali(BengaliPhoneticParser):
                     if ofe == 0:
                         sx = sx.replace(sx[ofe:ofe + len(ch)], self.shoroborno[ch])
                     else:
-                        prev_char_type = self._get_char_type(txt[ofe - 1])
-                        is_prev_one_kar_or_sworborno = prev_char_type == 'k' or prev_char_type == 'sb'
-                        if ch == "o" and is_prev_one_kar_or_sworborno:
-                            sx = sx.replace(sx[ofe:ofe + 1], "ও")
+                        is_prev_one_kar_or_sworborno = self._is_sworborno(txt[ofe - 1]) or self._is_kar(txt[ofe - 1])
+                        if ch == 'o' and is_prev_one_kar_or_sworborno:
+                            sx = sx.replace(sx[ofe:ofe + 1], 'ও')
                         elif txt[ofe - 1] == 'o' or is_prev_one_kar_or_sworborno:
                             sx = sx.replace(sx[ofe:ofe + len(ch)], self.shoroborno[ch])
                         else:
@@ -67,19 +58,19 @@ class BanglishToBengali(BengaliPhoneticParser):
         return sx
 
     def __change_x(self, txt):
-        sx = ""
+        sx = ''
         for i in range(0, len(txt)):
             if i == 0:
-                if "" + txt[i].lower() == "x":
-                    sx += "এক্স"
+                if '' + txt[i] == 'x':
+                    sx += 'এক্স'
                 else:
                     sx += txt[i]
             else:
-                if "" + txt[i].lower() == "x":
+                if '' + txt[i] == 'x':
                     if self.__is_alphabet(txt[i - 1]):
-                        sx += "ক্স"
+                        sx += 'ক্স'
                     else:
-                        sx += "এক্স"
+                        sx += 'এক্স'
                 else:
                     sx += txt[i]
         return sx
@@ -99,35 +90,35 @@ class BanglishToBengali(BengaliPhoneticParser):
 
         for a_three_char in self.three_char:
             banglish_string = self.__change(banglish_string, a_three_char, self.jukto_borno[a_three_char])
-        banglish_string = self.__change_sworborno(banglish_string, "rri")
+        banglish_string = self.__change_sworborno(banglish_string, 'rri')
 
         for a_two_char in self.two_char:
-            if (a_two_char in self.shoroborno.keys()):
+            if self._is_sworborno(a_two_char):
                 banglish_string = self.__change_sworborno(banglish_string, a_two_char)
-            elif (a_two_char in self.byanjon_borno.keys()):
-                banglish_string = self.__change(banglish_string, a_two_char, self.byanjon_borno[a_two_char])
-            elif (a_two_char in self.byanjon_borno.keys()):
+
+            elif self._is_byanjonborno(a_two_char):
                 banglish_string = self.__change(banglish_string, a_two_char, self.byanjon_borno[a_two_char])
 
         for a_one_char in self.one_char:
-            if (a_one_char in self.shoroborno.keys()):
+            if self._is_sworborno(a_one_char):
                 banglish_string = self.__change_sworborno(banglish_string, a_one_char)
-            elif (a_one_char in self.byanjon_borno.keys()):
+            elif self._is_byanjonborno(a_one_char):
                 banglish_string = self.__change(banglish_string, a_one_char, self.byanjon_borno[a_one_char])
-        banglish_string = self.__change(banglish_string, "o", "")
+
+        banglish_string = self.__change(banglish_string, 'o', '')
 
         return banglish_string
 
     def parse(self, banglish_text_to_parse):
-        converted_text = ""
+        converted_text = ''
 
-        for word in banglish_text_to_parse.split(" "):
+        for word in banglish_text_to_parse.split(' '):
             converted_text += '{} '.format(self.__convert(word))
 
         return converted_text.strip()
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     b2b = BanglishToBengali()
     while True:
         str_token = input()

--- a/bnbphoneticparser/banglishtobengali.py
+++ b/bnbphoneticparser/banglishtobengali.py
@@ -14,26 +14,25 @@ class BanglishToBengali(BengaliPhoneticParser):
         sx += txt
         if ch == 'a':
             asx = ''
-            for i in range(0, len(txt)):
+            for i, _ch in enumerate(txt):
                 if i == 0:
-                    if txt[i] == 'a':
+                    if _ch == 'a':
                         asx += 'আ'
                     else:
-                        asx += txt[i]
+                        asx += _ch
                 else:
-                    if txt[i] == 'a':
-                        is_prev_one_kar_or_sworborno = self._is_sworborno(txt[i - 1]) or self._is_kar(txt[i - 1])
-                        is_prev_one_byanjon_borno = self._is_byanjonborno(txt[i - 1])
-
-                        if is_prev_one_kar_or_sworborno:
-                            if txt[i - 1] == 'আ' or txt[i - 1] == 'া' or txt[i - 1] == 'a' or txt[i - 1] == 'A':
+                    if _ch == 'a':
+                        _prev_ch = txt[i - 1]
+                        if self._is_sworborno(_prev_ch) or self._is_kar(_prev_ch):
+                            if _prev_ch == 'আ' or _prev_ch == 'া' or _prev_ch == 'a' or _prev_ch == 'A':
                                 asx += 'আ'
                             else:
                                 asx += 'য়া'
-                        elif is_prev_one_byanjon_borno:
+                        elif self._is_byanjonborno(_prev_ch):
                             asx += 'া'
                     else:
-                        asx += txt[i]
+                        asx += _ch
+
             return asx
         else:
             ofe = sx.find(ch, 0)
@@ -83,13 +82,14 @@ class BanglishToBengali(BengaliPhoneticParser):
         banglish_string = self.__change_x(banglish_string)
 
         for a_five_char in self.five_char:
-            banglish_string = self.__change(banglish_string, a_five_char, self.jukto_borno[a_five_char])
+            banglish_string = self._change_to(banglish_string, a_five_char, self.jukto_borno[a_five_char])
 
         for a_four_char in self.four_char:
-            banglish_string = self.__change(banglish_string, a_four_char, self.jukto_borno[a_four_char])
+            banglish_string = self._change_to(banglish_string, a_four_char, self.jukto_borno[a_four_char])
 
         for a_three_char in self.three_char:
-            banglish_string = self.__change(banglish_string, a_three_char, self.jukto_borno[a_three_char])
+            banglish_string = self._change_to(banglish_string, a_three_char, self.jukto_borno[a_three_char])
+
         banglish_string = self.__change_sworborno(banglish_string, 'rri')
 
         for a_two_char in self.two_char:
@@ -97,15 +97,15 @@ class BanglishToBengali(BengaliPhoneticParser):
                 banglish_string = self.__change_sworborno(banglish_string, a_two_char)
 
             elif self._is_byanjonborno(a_two_char):
-                banglish_string = self.__change(banglish_string, a_two_char, self.byanjon_borno[a_two_char])
+                banglish_string = self._change_to(banglish_string, a_two_char, self.byanjon_borno[a_two_char])
 
         for a_one_char in self.one_char:
             if self._is_sworborno(a_one_char):
                 banglish_string = self.__change_sworborno(banglish_string, a_one_char)
             elif self._is_byanjonborno(a_one_char):
-                banglish_string = self.__change(banglish_string, a_one_char, self.byanjon_borno[a_one_char])
+                banglish_string = self._change_to(banglish_string, a_one_char, self.byanjon_borno[a_one_char])
 
-        banglish_string = self.__change(banglish_string, 'o', '')
+        banglish_string = self._change_to(banglish_string, 'o', '')
 
         return banglish_string
 

--- a/bnbphoneticparser/banglishtobengali.py
+++ b/bnbphoneticparser/banglishtobengali.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 import re
 
-from .bengaliphoneticparser import *
+from .bengaliphoneticparser import BengaliPhoneticParser
 
 
 class BanglishToBengali(BengaliPhoneticParser):

--- a/bnbphoneticparser/bengaliphoneticparser.py
+++ b/bnbphoneticparser/bengaliphoneticparser.py
@@ -153,6 +153,10 @@ class BengaliPhoneticParser:
     def _exists(_map, segment):
         return segment.lower() in _map or segment.lower() in _map.values()
 
+    @staticmethod
+    def _change_to(txt, ch, nch):
+        return txt.replace(ch, nch)
+
     def _is_sworborno(self, segment):
         return self._exists(self.shoroborno, segment)
 
@@ -161,14 +165,6 @@ class BengaliPhoneticParser:
 
     def _is_kar(self, segment):
         return self._exists(self.kar, segment)
-
-
-
-    def change(self, txt, ch, nch):
-        pass
-
-    def change_sworborno(self, txt, ch):
-        pass
 
     def convert(self, text_to_convert):
         pass

--- a/bnbphoneticparser/bengaliphoneticparser.py
+++ b/bnbphoneticparser/bengaliphoneticparser.py
@@ -148,18 +148,30 @@ class BengaliPhoneticParser:
         "chr": "ছ্র", "dbhr": "দ্ভ্র"
     }
 
+    '''Segment instead of char, since it can be of multiple chars instead of one.'''
+    @staticmethod
+    def _exists(_map, segment):
+        return segment.lower() in _map or segment.lower() in _map.values()
+
+    def _is_sworborno(self, segment):
+        return self._exists(self.shoroborno, segment)
+
+    def _is_byanjonborno(self, segment):
+        return self._exists(self.byanjon_borno, segment)
+
+    def _is_kar(self, segment):
+        return self._exists(self.kar, segment)
+
+
 
     def change(self, txt, ch, nch):
         pass
 
-
     def change_sworborno(self, txt, ch):
         pass
 
-
     def convert(self, text_to_convert):
         pass
-
 
     def parse(self, text_to_parse):
         pass

--- a/bnbphoneticparser/bengalitobanglish.py
+++ b/bnbphoneticparser/bengalitobanglish.py
@@ -9,16 +9,16 @@ class BengaliToBanglish(BengaliPhoneticParser):
         char_list2 = [v for k, v in self.kar.items()]
         char_list3 = [v for k, v in self.byanjon_borno.items()]
         char_list4 = [v for k, v in self.jukto_borno.items()]
-        char_list = char_list1+char_list2+char_list3+char_list4
+        char_list = char_list1 + char_list2 + char_list3 + char_list4
         self.onechar = [char for char in char_list if len(char) == 1]
         self.twochar = [char for char in char_list if len(char) == 2]
         self.threechar = [char for char in char_list if len(char) == 3]
         self.fourchar = [char for char in char_list if len(char) == 4]
         self.fivechar = [char for char in char_list if len(char) == 5]
-        self.__shoroborno = dict((v.strip(), k.strip()) for k, v in self.shoroborno.items())
-        self.__kar = dict((v.strip(), k.strip()) for k, v in self.kar.items())
-        self.__byanjon_borno = dict((v.strip(), k.strip()) for k, v in self.byanjon_borno.items())
-        self.__jukto_borno = dict((v.strip(), k.strip()) for k, v in self.jukto_borno.items())
+        self.shoroborno_reverse_map = dict((v.strip(), k.strip()) for k, v in self.shoroborno.items())
+        self.kar_reverse_map = dict((v.strip(), k.strip()) for k, v in self.kar.items())
+        self.byanjon_borno_reverse_map = dict((v.strip(), k.strip()) for k, v in self.byanjon_borno.items())
+        self.jukto_borno_reverse_map = dict((v.strip(), k.strip()) for k, v in self.jukto_borno.items())
 
     def __change_sworborno(self, txt, ch):
         sx = ""
@@ -41,7 +41,7 @@ class BengaliToBanglish(BengaliPhoneticParser):
                     elif _ch == "অ" and self._is_byanjonborno(_prev_ch):
                         asx += "আ"
                     elif self._is_kar(_ch):
-                        asx += self.__kar[_ch]
+                        asx += self.kar_reverse_map[_ch]
                     else:
                         asx += _ch
 
@@ -55,16 +55,16 @@ class BengaliToBanglish(BengaliPhoneticParser):
                     break
                 else:
                     if ofe == 0:
-                        sx = sx.replace(sx[ofe:ofe + len(ch)], self.__shoroborno[ch])
+                        sx = sx.replace(sx[ofe:ofe + len(ch)], self.shoroborno_reverse_map[ch])
                     else:
                         _prev_och = txt[ofe - 1]
                         if ch == "ও" and self._is_sworborno(_prev_och) or self._is_kar(_prev_och):
                             sx = sx.replace(sx[ofe:ofe + 1], "ও")
                         elif self._is_sworborno(_prev_och) or self._is_kar(_prev_och) or _prev_och == "ও":
-                            sx = sx.replace(sx[ofe:ofe + len(ch)], self.__shoroborno[ch])
+                            sx = sx.replace(sx[ofe:ofe + len(ch)], self.shoroborno_reverse_map[ch])
                         else:
                             if txt[ofe] != "ও":
-                                sx = sx.replace(sx[ofe:ofe + len(ch)], self.__kar[ch])
+                                sx = sx.replace(sx[ofe:ofe + len(ch)], self.kar_reverse_map[ch])
                 ofs = ofe + 1
 
         return sx
@@ -83,41 +83,58 @@ class BengaliToBanglish(BengaliPhoneticParser):
     def __is_alphabet(self, code):
         return code.isalpha()
 
-    def __convert(self, bengali_string):
+    def _get_replacement_char(self, char_to_replace):
+        replacement_maps = [
+            self.jukto_borno_reverse_map,
+            self.byanjon_borno_reverse_map,
+            self.shoroborno_reverse_map,
+            self.kar_reverse_map
+        ]
 
+        replacement_char = None
+
+        for replacement_map in replacement_maps:
+            replacement_char = replacement_map.get(char_to_replace, None)
+            if replacement_char:
+                break
+
+        return replacement_char if replacement_char else ''
+
+    def __convert(self, bengali_string):
         bengali_string = self.__change_x(bengali_string)
         for a_five_char in self.fivechar:
-            bengali_string = self._change_to(bengali_string, a_five_char, self.__jukto_borno[a_five_char])
+            bengali_string = self._change_to(bengali_string, a_five_char, self._get_replacement_char(a_five_char))
 
         for a_four_char in self.fourchar:
-            bengali_string = self._change_to(bengali_string, a_four_char, self.__jukto_borno[a_four_char])
+            bengali_string = self._change_to(bengali_string, a_four_char, self._get_replacement_char(a_four_char))
 
         for a_three_char in self.threechar:
-            bengali_string = self._change_to(bengali_string, a_three_char, self.__jukto_borno[a_three_char])
+            bengali_string = self._change_to(bengali_string, a_three_char, self._get_replacement_char(a_three_char))
+
         bengali_string = self.__change_sworborno(bengali_string, "rri")
 
         for a_two_char in self.twochar:
             if self._is_sworborno(a_two_char):
                 bengali_string = self.__change_sworborno(bengali_string, a_two_char)
             elif self._is_byanjonborno(a_two_char):
-                bengali_string = self._change_to(bengali_string, a_two_char, self.__byanjon_borno[a_two_char])
+                bengali_string = self._change_to(bengali_string, a_two_char, self.byanjon_borno_reverse_map[a_two_char])
 
         for a_one_char in self.onechar:
             if self._is_sworborno(a_one_char):
                 bengali_string = self.__change_sworborno(bengali_string, a_one_char)
             elif self._is_byanjonborno(a_one_char):
-                bengali_string = self._change_to(bengali_string, a_one_char, self.__byanjon_borno[a_one_char])
+                bengali_string = self._change_to(bengali_string, a_one_char, self.byanjon_borno_reverse_map[a_one_char])
         bengali_string = self._change_to(bengali_string, "ও", "")
 
         return bengali_string
 
-    def parse(self, bengali_text_to_parse):
-        separated_word = bengali_text_to_parse.split(" ")
-        converted_text = ""
-        for i in range(0, len(separated_word)):
-            converted_text = converted_text + self.__convert(separated_word[i]) + " "
+    def parse(self, banglish_text_to_parse):
+        converted_text = ''
 
-        return converted_text.strip().lower()
+        for word in banglish_text_to_parse.split(' '):
+            converted_text += '{} '.format(self.__convert(word))
+
+        return converted_text.strip()
 
 
 if __name__ == "__main__":

--- a/bnbphoneticparser/bengalitobanglish.py
+++ b/bnbphoneticparser/bengalitobanglish.py
@@ -20,120 +20,96 @@ class BengaliToBanglish(BengaliPhoneticParser):
         self.__byanjon_borno = dict((v.strip(), k.strip()) for k, v in self.byanjon_borno.items())
         self.__jukto_borno = dict((v.strip(), k.strip()) for k, v in self.jukto_borno.items())
 
-
-    def __change(self, txt, ch, nch):
-        return txt.replace(ch, nch)
-
-
     def __change_sworborno(self, txt, ch):
         sx = ""
         sx += txt
-        if (ch == "আ"):
+        if ch == "আ":
             asx = ""
-            for i in range(0, len(txt)):
-                if (i == 0):
-                    if ("" + txt[i] == "আ"):
+            for i, _ch in enumerate(txt):
+                if i == 0:
+                    if _ch == "আ":
                         asx += "a"
                     else:
-                        asx += txt[i]
+                        asx += _ch
                 else:
-                    if (("" + txt[i] == "আ") and (("" + txt[i - 1] in self.__shoroborno.values()) or
-                                                              ("" + txt[i - 1] in self.__shoroborno.keys()) or
-                                                              ("" + txt[i - 1] in self.__kar.keys()) or
-                                                              ("" + txt[i - 1] in self.__kar.values()))):
-                        if (("" + txt[i - 1] == "a") or ("" + txt[i - 1] == "a") or ("" + txt[i - 1] == "আ") or (
-                                        "" + txt[i - 1] == "অ")):
+                    _prev_ch = txt[i - 1]
+                    if _ch == "আ" and self._is_sworborno(_prev_ch) or self._is_kar(_prev_ch):
+                        if _prev_ch == "a" or _prev_ch == "আ" or _prev_ch == "অ":
                             asx += "a"
                         else:
                             asx += "ya"
-                    elif (("" + txt[i] == "অ") and (("" + txt[i - 1] in self.__byanjon_borno.values()) or
-                                                                ("" + txt[i - 1] in self.__byanjon_borno.keys()) or (
-                                    "" + txt[i - 1] in self.__byanjon_borno.keys())
-                                                            or ("" + txt[i - 1] in self.__byanjon_borno.values()))):
+                    elif _ch == "অ" and self._is_byanjonborno(_prev_ch):
                         asx += "আ"
-                    elif txt[i] in self.__kar.keys():
-                        asx += "" + self.__kar[txt[i]]
+                    elif self._is_kar(_ch):
+                        asx += self.__kar[_ch]
                     else:
-                        asx += "" + txt[i]
+                        asx += _ch
+
             return asx
         else:
             ofe = sx.find(ch, 0)
             ofs = 0
             while ofs < len(txt) and (ofe != -1):
                 ofe = sx.find(ch, ofs)
-                # print(ofe)
-                if (ofe == -1):
+                if ofe == -1:
                     break
                 else:
-                    if (ofe == 0):
-                        # print(sx)
+                    if ofe == 0:
                         sx = sx.replace(sx[ofe:ofe + len(ch)], self.__shoroborno[ch])
                     else:
-                        if (ch == "ও" and (("" + txt[ofe - 1] in self.__shoroborno.values()) or (
-                                        "" + txt[ofe - 1] in self.__shoroborno.keys())
-                                           or ("" + txt[ofe - 1] in self.__kar.keys()) or (
-                                        "" + txt[ofe - 1] in self.__kar.values()))):
+                        _prev_och = txt[ofe - 1]
+                        if ch == "ও" and self._is_sworborno(_prev_och) or self._is_kar(_prev_och):
                             sx = sx.replace(sx[ofe:ofe + 1], "ও")
-                        elif (("" + txt[ofe - 1] in self.__shoroborno.values()) or (
-                                        "" + txt[ofe - 1] in self.__shoroborno.keys())
-                              or ("" + txt[ofe - 1] in self.__kar.keys()) or (
-                                        "" + txt[ofe - 1] in self.__kar.values()) or
-                                  ("" + txt[ofe - 1] == "ও")):
+                        elif self._is_sworborno(_prev_och) or self._is_kar(_prev_och) or _prev_och == "ও":
                             sx = sx.replace(sx[ofe:ofe + len(ch)], self.__shoroborno[ch])
                         else:
-                            if ("" + txt[ofe] != "ও"):
+                            if txt[ofe] != "ও":
                                 sx = sx.replace(sx[ofe:ofe + len(ch)], self.__kar[ch])
                 ofs = ofe + 1
 
         return sx
 
-
     def __change_x(self, txt):
         sx = ""
-        if ("" + txt == "এক্স"):
+        if txt == "এক্স":
             sx += "x"
-        elif ("" + txt == "ক্স"):
+        elif txt == "ক্স":
             sx += "x"
         else:
             sx += txt
 
         return sx
 
-
     def __is_alphabet(self, code):
         return code.isalpha()
-
 
     def __convert(self, bengali_string):
 
         bengali_string = self.__change_x(bengali_string)
         for a_five_char in self.fivechar:
-            bengali_string = self.__change(bengali_string, a_five_char, self.__jukto_borno[a_five_char])
+            bengali_string = self._change_to(bengali_string, a_five_char, self.__jukto_borno[a_five_char])
 
         for a_four_char in self.fourchar:
-            bengali_string = self.__change(bengali_string, a_four_char, self.__jukto_borno[a_four_char])
+            bengali_string = self._change_to(bengali_string, a_four_char, self.__jukto_borno[a_four_char])
 
         for a_three_char in self.threechar:
-            bengali_string = self.__change(bengali_string, a_three_char, self.__jukto_borno[a_three_char])
+            bengali_string = self._change_to(bengali_string, a_three_char, self.__jukto_borno[a_three_char])
         bengali_string = self.__change_sworborno(bengali_string, "rri")
 
         for a_two_char in self.twochar:
-            if (a_two_char in self.__shoroborno.keys()):
+            if self._is_sworborno(a_two_char):
                 bengali_string = self.__change_sworborno(bengali_string, a_two_char)
-            elif (a_two_char in self.__byanjon_borno.keys()):
-                bengali_string = self.__change(bengali_string, a_two_char, self.__byanjon_borno[a_two_char])
-            elif (a_two_char in self.__byanjon_borno.keys()):
-                bengali_string = self.__change(bengali_string, a_two_char, self.__byanjon_borno[a_two_char])
+            elif self._is_byanjonborno(a_two_char):
+                bengali_string = self._change_to(bengali_string, a_two_char, self.__byanjon_borno[a_two_char])
 
         for a_one_char in self.onechar:
-            if (a_one_char in self.__shoroborno.keys()):
+            if self._is_sworborno(a_one_char):
                 bengali_string = self.__change_sworborno(bengali_string, a_one_char)
-            elif (a_one_char in self.__byanjon_borno.keys()):
-                bengali_string = self.__change(bengali_string, a_one_char, self.__byanjon_borno[a_one_char])
-        bengali_string = self.__change(bengali_string, "ও", "")
+            elif self._is_byanjonborno(a_one_char):
+                bengali_string = self._change_to(bengali_string, a_one_char, self.__byanjon_borno[a_one_char])
+        bengali_string = self._change_to(bengali_string, "ও", "")
 
         return bengali_string
-
 
     def parse(self, bengali_text_to_parse):
         separated_word = bengali_text_to_parse.split(" ")

--- a/bnbphoneticparser/bengalitobanglish.py
+++ b/bnbphoneticparser/bengalitobanglish.py
@@ -57,10 +57,10 @@ class BengaliToBanglish(BengaliPhoneticParser):
                     if ofe == 0:
                         sx = sx.replace(sx[ofe:ofe + len(ch)], self.shoroborno_reverse_map[ch])
                     else:
-                        _prev_och = txt[ofe - 1]
-                        if ch == "ও" and self._is_sworborno(_prev_och) or self._is_kar(_prev_och):
+                        is_prev_one_kar_or_sworborno = self._is_sworborno(txt[ofe - 1]) or self._is_kar(txt[ofe - 1])
+                        if ch == "ও" and is_prev_one_kar_or_sworborno:
                             sx = sx.replace(sx[ofe:ofe + 1], "ও")
-                        elif self._is_sworborno(_prev_och) or self._is_kar(_prev_och) or _prev_och == "ও":
+                        elif is_prev_one_kar_or_sworborno or txt[ofe - 1] == "ও":
                             sx = sx.replace(sx[ofe:ofe + len(ch)], self.shoroborno_reverse_map[ch])
                         else:
                             if txt[ofe] != "ও":

--- a/bnbphoneticparser/bengalitobanglish.py
+++ b/bnbphoneticparser/bengalitobanglish.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from .bengaliphoneticparser import *
+from .bengaliphoneticparser import BengaliPhoneticParser
 
 
 class BengaliToBanglish(BengaliPhoneticParser):
@@ -21,25 +21,25 @@ class BengaliToBanglish(BengaliPhoneticParser):
         self.jukto_borno_reverse_map = dict((v.strip(), k.strip()) for k, v in self.jukto_borno.items())
 
     def __change_sworborno(self, txt, ch):
-        sx = ""
+        sx = ''
         sx += txt
-        if ch == "আ":
-            asx = ""
+        if ch == 'আ':
+            asx = ''
             for i, _ch in enumerate(txt):
                 if i == 0:
-                    if _ch == "আ":
-                        asx += "a"
+                    if _ch == 'আ':
+                        asx += 'a'
                     else:
                         asx += _ch
                 else:
                     _prev_ch = txt[i - 1]
-                    if _ch == "আ" and self._is_sworborno(_prev_ch) or self._is_kar(_prev_ch):
-                        if _prev_ch == "a" or _prev_ch == "আ" or _prev_ch == "অ":
-                            asx += "a"
+                    if _ch == 'আ' and self._is_sworborno(_prev_ch) or self._is_kar(_prev_ch):
+                        if _prev_ch == 'a' or _prev_ch == 'আ' or _prev_ch == 'অ':
+                            asx += 'a'
                         else:
-                            asx += "ya"
-                    elif _ch == "অ" and self._is_byanjonborno(_prev_ch):
-                        asx += "আ"
+                            asx += 'ya'
+                    elif _ch == 'অ' and self._is_byanjonborno(_prev_ch):
+                        asx += 'আ'
                     elif self._is_kar(_ch):
                         asx += self.kar_reverse_map[_ch]
                     else:
@@ -58,23 +58,23 @@ class BengaliToBanglish(BengaliPhoneticParser):
                         sx = sx.replace(sx[ofe:ofe + len(ch)], self.shoroborno_reverse_map[ch])
                     else:
                         is_prev_one_kar_or_sworborno = self._is_sworborno(txt[ofe - 1]) or self._is_kar(txt[ofe - 1])
-                        if ch == "ও" and is_prev_one_kar_or_sworborno:
-                            sx = sx.replace(sx[ofe:ofe + 1], "ও")
-                        elif is_prev_one_kar_or_sworborno or txt[ofe - 1] == "ও":
+                        if ch == 'ও' and is_prev_one_kar_or_sworborno:
+                            sx = sx.replace(sx[ofe:ofe + 1], 'ও')
+                        elif is_prev_one_kar_or_sworborno or txt[ofe - 1] == 'ও':
                             sx = sx.replace(sx[ofe:ofe + len(ch)], self.shoroborno_reverse_map[ch])
                         else:
-                            if txt[ofe] != "ও":
+                            if txt[ofe] != 'ও':
                                 sx = sx.replace(sx[ofe:ofe + len(ch)], self.kar_reverse_map[ch])
                 ofs = ofe + 1
 
         return sx
 
     def __change_x(self, txt):
-        sx = ""
-        if txt == "এক্স":
-            sx += "x"
-        elif txt == "ক্স":
-            sx += "x"
+        sx = ''
+        if txt == 'এক্স':
+            sx += 'x'
+        elif txt == 'ক্স':
+            sx += 'x'
         else:
             sx += txt
 
@@ -111,7 +111,7 @@ class BengaliToBanglish(BengaliPhoneticParser):
         for a_three_char in self.threechar:
             bengali_string = self._change_to(bengali_string, a_three_char, self._get_replacement_char(a_three_char))
 
-        bengali_string = self.__change_sworborno(bengali_string, "rri")
+        bengali_string = self.__change_sworborno(bengali_string, 'rri')
 
         for a_two_char in self.twochar:
             if self._is_sworborno(a_two_char):
@@ -124,7 +124,7 @@ class BengaliToBanglish(BengaliPhoneticParser):
                 bengali_string = self.__change_sworborno(bengali_string, a_one_char)
             elif self._is_byanjonborno(a_one_char):
                 bengali_string = self._change_to(bengali_string, a_one_char, self.byanjon_borno_reverse_map[a_one_char])
-        bengali_string = self._change_to(bengali_string, "ও", "")
+        bengali_string = self._change_to(bengali_string, 'ও', '')
 
         return bengali_string
 
@@ -137,7 +137,7 @@ class BengaliToBanglish(BengaliPhoneticParser):
         return converted_text.strip()
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     b2b = BengaliToBanglish()
     while True:
         str_token = input()

--- a/tests/banglishtobengali.py
+++ b/tests/banglishtobengali.py
@@ -11,4 +11,5 @@ class TestBanglishToBengali(TestCase):
         self.assertEqual(b2b.parse("muRi"), "মুড়ি")
         self.assertEqual(b2b.parse("AmAr"), "আমার")
         self.assertEqual(b2b.parse("AmAr poran"), "আমার পরান")
+        self.assertEqual(b2b.parse("mn val nei"), "মন ভাল নেই")
 

--- a/tests/bengalitobanglish.py
+++ b/tests/bengalitobanglish.py
@@ -8,5 +8,6 @@ class TestBengaliToBanglish(TestCase):
     def test_bengali_to_banglish_parse(self):
         b2b = BengaliToBanglish()
         self.assertEqual(b2b.parse("ফ"), "f")
-        self.assertEqual(b2b.parse("মুড়ি"), "muri")
+        self.assertEqual(b2b.parse("মুড়ি"), "muRi")
+        self.assertEqual(b2b.parse("মন ভাল নেই"), "mn val nei")
 


### PR DESCRIPTION
- Instead of accessing maps from base class(e.g. `soroborno, kar`), helpers methods must be there to check which character is of which type(e.g. `is_soroborno`); that way repetitions are mitigated

- Simplify how replacements were happening in bengali to banglish parser- which also fixes a bug where `মন ভাল নেই` actually fails because of one segment is considered to be consisted of 3 characters and by default we start looking up in jukto borno map; whereas the actual mapping exists in byanjon borno instead

- Make code simpler, much readable and consistent among the classes

- Add more vice versa tests

- Use single quote for strings instead of double [python standard]